### PR TITLE
add awsutils_security_hub_organization_settings

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -12,8 +12,6 @@ provider "awsutils" {
   region = "us-east-1"
 }
 
-## TODO: Update this once we have some resources
-# Create a VPC
-resource "awsutils_vpc" "example" {
-  cidr_block = "10.0.0.0/16"
+# Delete default VPC
+resource "awsutils_default_vpc_deletion" "example" {
 }

--- a/examples/resources/awsutils_security_hub_organization_settings/resource.tf
+++ b/examples/resources/awsutils_security_hub_organization_settings/resource.tf
@@ -1,0 +1,21 @@
+terraform {
+  required_providers {
+    awsutils = {
+      source = "cloudposse/awsutils"
+      # For local development,
+      # install the provider on local computer by running `make install` from the root of the repo, and uncomment the 
+      # version below
+      # version = "9999.99.99"
+    }
+  }
+}
+
+provider "awsutils" {
+  region = "us-east-1"
+}
+
+# Delete the default VPC in our account/region
+resource "awsutils_security_hub_organization_settings" "default" {
+  member_accounts          = ["111111111111", "222222222222"]
+  auto_enable_new_accounts = true
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.38.67
 	github.com/fatih/color v1.9.0 // indirect
+	github.com/google/uuid v1.2.0
 	github.com/hashicorp/aws-sdk-go-base v0.7.1
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-multierror v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hf
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
+github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5 h1:sjZBwGj9Jlw33ImPtvFviGYvseOtDM7hkSKB7+Tv3SM=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -186,8 +186,9 @@ func Provider() *schema.Provider {
 		DataSourcesMap: map[string]*schema.Resource{},
 
 		ResourcesMap: map[string]*schema.Resource{
-			"awsutils_default_vpc_deletion":             resourceAwsUtilsDefaultVpcDeletion(),
-			"awsutils_security_hub_control_disablement": resourceAwsUtilsSecurityHubControlDisablement(),
+			"awsutils_default_vpc_deletion":               resourceAwsUtilsDefaultVpcDeletion(),
+			"awsutils_security_hub_control_disablement":   resourceAwsUtilsSecurityHubControlDisablement(),
+			"awsutils_security_hub_organization_settings": resourceAwsUtilsSecurityHubOrganizationSettings(),
 		},
 	}
 

--- a/internal/provider/resource_awsutils_security_hub_organization_settings.go
+++ b/internal/provider/resource_awsutils_security_hub_organization_settings.go
@@ -1,0 +1,181 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/securityhub"
+	"github.com/cloudposse/terraform-provider-awsutils/internal/service/securityhub/finder"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func resourceAwsUtilsSecurityHubOrganizationSettings() *schema.Resource {
+	return &schema.Resource{
+		Description: `Enables a list of accounts as Security Hub member accounts in an existing AWS Organization.
+
+Designating an account as the Security Hub Administrator account in an AWS Organization can optionally enable all 
+newly created accounts and accounts that join the organization after the setting is enabled, however it does not 
+enable existing accounts. Use this resource to enable a list of existing accounts`,
+		Create:        resourceAwsSecurityHubOrganizationSettingsCreate,
+		Read:          resourceAwsSecurityHubOrganizationSettingsRead,
+		Update:        resourceAwsSecurityHubOrganizationSettingsUpdate,
+		Delete:        resourceAwsSecurityHubOrganizationSettingsDelete,
+		SchemaVersion: 1,
+		Schema: map[string]*schema.Schema{
+			"member_accounts": {
+				Description: "A list of AWS Organization member accounts to associate with the Security Hub Administrator account.",
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Required:    true,
+			},
+			"auto_enable_new_accounts": {
+				Description: "A flag to indicate if the automatic enablement setting, should be enabled. If enabled, Security Hub begins to enable new accounts as they are added to the organization",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+			},
+		},
+	}
+}
+
+func resourceAwsSecurityHubOrganizationSettingsCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+	memberAccounts := ExpandStringSliceofPointers(ExpandStringSet(d.Get("member_accounts").(*schema.Set)))
+	autoEnable := d.Get("auto_enable_new_accounts").(bool)
+
+	if err := addSecurityHubOrganizationMembers(conn, memberAccounts); err != nil {
+		return err
+	}
+
+	if err := updateSecurityHubOrganizationSettings(conn, autoEnable); err != nil {
+		return err
+	}
+
+	d.SetId(uuid.New().String())
+
+	return resourceAwsSecurityHubOrganizationSettingsRead(d, meta)
+}
+
+func resourceAwsSecurityHubOrganizationSettingsRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+
+	enabled, err := finder.SecurityHubOrganizationSettingsAutoEnabled(conn)
+	if err != nil {
+		return fmt.Errorf("error reading security hub organization settings: %s", err)
+	}
+
+	d.Set("auto_enable_new_accounts", enabled)
+
+	return nil
+}
+
+func resourceAwsSecurityHubOrganizationSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).securityhubconn
+	if d.HasChanges("auto_enable_new_accounts") {
+		_, new := d.GetChange("auto_enable_new_accounts")
+		autoEnable := new.(bool)
+
+		if err := updateSecurityHubOrganizationSettings(conn, autoEnable); err != nil {
+			return fmt.Errorf("error updating security hub organization settings: %s", err)
+		}
+	}
+
+	if d.HasChange("member_accounts") {
+		old, new := d.GetChange("member_accounts")
+
+		oldExpanded := ExpandStringSliceofPointers(ExpandStringSet(old.(*schema.Set)))
+		newExpanded := ExpandStringSliceofPointers(ExpandStringSet(new.(*schema.Set)))
+
+		membersToAdd := Diff(newExpanded, oldExpanded)
+		if len(membersToAdd) > 0 {
+			if err := addSecurityHubOrganizationMembers(conn, membersToAdd); err != nil {
+				return fmt.Errorf("error setting security hub organization members: %s", err)
+			}
+		}
+
+		membersToRemove := Diff(oldExpanded, newExpanded)
+		if len(membersToRemove) > 0 {
+			if err := removeSecurityHubOrganizationMembers(conn, membersToRemove); err != nil {
+				return fmt.Errorf("error removing security hub organization members: %s", err)
+			}
+		}
+	}
+	return nil
+}
+
+func resourceAwsSecurityHubOrganizationSettingsDelete(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func updateSecurityHubOrganizationSettings(conn *securityhub.SecurityHub, autoEnable bool) error {
+	updateOrgSettingsInput := &securityhub.UpdateOrganizationConfigurationInput{
+		AutoEnable: aws.Bool(autoEnable),
+	}
+	if _, err := conn.UpdateOrganizationConfiguration(updateOrgSettingsInput); err != nil {
+		return fmt.Errorf("error updating security hub administrator account settings: %s", err)
+	}
+	return nil
+}
+
+func makeAccountDetails(accounts []string) []*securityhub.AccountDetails {
+	accountDetails := make([]*securityhub.AccountDetails, 0)
+	for i := range accounts {
+		accountDetails = append(accountDetails, &securityhub.AccountDetails{AccountId: aws.String(accounts[i])})
+	}
+	return accountDetails
+}
+
+func makeAccountIDs(accounts []string) []*string {
+	accountIDs := make([]*string, 0)
+	for i := range accounts {
+		accountIDs = append(accountIDs, aws.String(accounts[i]))
+	}
+	return accountIDs
+}
+
+func addSecurityHubOrganizationMembers(conn *securityhub.SecurityHub, memberAccounts []string) error {
+	if len(memberAccounts) > 0 {
+		accountDetails := makeAccountDetails(memberAccounts)
+
+		createMembersInput := &securityhub.CreateMembersInput{
+			AccountDetails: accountDetails,
+		}
+
+		if result, err := conn.CreateMembers(createMembersInput); err != nil || len(result.UnprocessedAccounts) > 0 {
+			if err != nil {
+				return fmt.Errorf("error designating security hub administrator account members: %s", err)
+			}
+			return fmt.Errorf("error designating security hub administrator account members: %s", result.UnprocessedAccounts)
+		}
+	}
+	return nil
+}
+
+func removeSecurityHubOrganizationMembers(conn *securityhub.SecurityHub, memberAccounts []string) error {
+	accountIDs := makeAccountIDs(memberAccounts)
+	if len(memberAccounts) > 0 {
+		disassociateMembersInput := &securityhub.DisassociateMembersInput{
+			AccountIds: accountIDs,
+		}
+
+		deleteMembersInput := &securityhub.DeleteMembersInput{
+			AccountIds: accountIDs,
+		}
+
+		if _, err := conn.DisassociateMembers(disassociateMembersInput); err != nil {
+			if err != nil {
+				return fmt.Errorf("error disassociating security hub administrator account members: %s", err)
+			}
+		}
+
+		if result, err := conn.DeleteMembers(deleteMembersInput); err != nil || len(result.UnprocessedAccounts) > 0 {
+			if err != nil {
+				return fmt.Errorf("error removing security hub administrator account members: %s", err)
+			}
+			return fmt.Errorf("error removing security hub administrator account members: %s", result.UnprocessedAccounts)
+		}
+	}
+	return nil
+}

--- a/internal/provider/structure.go
+++ b/internal/provider/structure.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func contains(s []string, str string) bool {
+	for _, v := range s {
+		if v == str {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Diff returns the elements in `slice1` that aren't in `slice2`.
+func Diff(slice1 []string, slice2 []string) []string {
+	var diff []string
+
+	for _, s1 := range slice1 {
+		if !contains(slice2, s1) {
+			diff = append(diff, s1)
+		}
+	}
+
+	return diff
+}
+
+// Takes a slice of pointers to string and returns a slice of strings
+func ExpandStringSliceofPointers(input []*string) []string {
+	var output []string
+
+	for _, s := range input {
+		output = append(output, *s)
+	}
+	return output
+}
+
+// Takes the result of flatmap.Expand for an array of strings and returns a []*string
+func ExpandStringList(configured []interface{}) []*string {
+	vs := make([]*string, 0, len(configured))
+	for _, v := range configured {
+		val, ok := v.(string)
+		if ok && val != "" {
+			vs = append(vs, aws.String(v.(string)))
+		}
+	}
+	return vs
+}
+
+// Takes the result of schema.Set of strings and returns a []*string
+func ExpandStringSet(configured *schema.Set) []*string {
+	return ExpandStringList(configured.List())
+}

--- a/internal/service/securityhub/finder/finder.go
+++ b/internal/service/securityhub/finder/finder.go
@@ -63,3 +63,13 @@ func SecurityHubControl(conn *securityhub.SecurityHub, controlArn string) (*secu
 		Message: fmt.Sprintf("%s is not a valid control arn", controlArn),
 	}
 }
+
+func SecurityHubOrganizationSettingsAutoEnabled(conn *securityhub.SecurityHub) (bool, error) {
+	input := &securityhub.DescribeOrganizationConfigurationInput{}
+	settings, err := conn.DescribeOrganizationConfiguration(input)
+	if err != nil {
+		return false, err
+	}
+
+	return *settings.AutoEnable, err
+}


### PR DESCRIPTION
## what

* Add the `awsutils_security_hub_organization_settings` resource

## why
* The official AWS Terraform Provider does not provide a method to enroll existing AWS Organization accounts when setting a Security Hub Administrator account