### PR TITLE
add awsutils_guardduty_organization_settings resource

### DIFF
--- a/examples/resources/awsutils_guardduty_organization_settings/resource.tf
+++ b/examples/resources/awsutils_guardduty_organization_settings/resource.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_providers {
+    awsutils = {
+      source = "cloudposse/awsutils"
+      # For local development,
+      # install the provider on local computer by running `make install` from the root of the repo, and uncomment the 
+      # version below
+      # version = "9999.99.99"
+    }
+  }
+}
+
+provider "awsutils" {
+  region = "us-east-1"
+}
+
+resource "awsutils_guardduty_organization_settings" "default" {
+  member_accounts = ["111111111111", "22222222222"]
+  detector_id     = "42bd3eab69b96663418094bb59397d1f"
+}

--- a/examples/resources/awsutils_security_hub_control_disablement/resource.tf
+++ b/examples/resources/awsutils_security_hub_control_disablement/resource.tf
@@ -14,7 +14,6 @@ provider "awsutils" {
   region = "us-east-1"
 }
 
-# Delete the default VPC in our account/region
 resource "awsutils_security_hub_control_disablement" "default" {
   control_arn = "arn:aws:securityhub:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:control/cis-aws-foundations-benchmark/v/1.2.0/1.1"
   reason      = "Global Resources are not evaluated in this region"

--- a/examples/resources/awsutils_security_hub_organization_settings/resource.tf
+++ b/examples/resources/awsutils_security_hub_organization_settings/resource.tf
@@ -14,7 +14,6 @@ provider "awsutils" {
   region = "us-east-1"
 }
 
-# Delete the default VPC in our account/region
 resource "awsutils_security_hub_organization_settings" "default" {
   member_accounts          = ["111111111111", "222222222222"]
   auto_enable_new_accounts = true

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -187,6 +187,7 @@ func Provider() *schema.Provider {
 
 		ResourcesMap: map[string]*schema.Resource{
 			"awsutils_default_vpc_deletion":               resourceAwsUtilsDefaultVpcDeletion(),
+			"awsutils_guardduty_organization_settings":    resourceAwsUtilsGuardDutyOrganizationSettings(),
 			"awsutils_security_hub_control_disablement":   resourceAwsUtilsSecurityHubControlDisablement(),
 			"awsutils_security_hub_organization_settings": resourceAwsUtilsSecurityHubOrganizationSettings(),
 		},

--- a/internal/provider/resource_awsutils_guardduty_organization_settings.go
+++ b/internal/provider/resource_awsutils_guardduty_organization_settings.go
@@ -1,0 +1,169 @@
+package provider
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func resourceAwsUtilsGuardDutyOrganizationSettings() *schema.Resource {
+	return &schema.Resource{
+		Description: `Enables a list of accounts as GuardDuty member accounts in an existing AWS Organization.
+
+Designating an account as the GuardDuty Administrator account in an AWS Organization can optionally enable all 
+newly created accounts and accounts that join the organization after the setting is enabled, however it does not 
+enable existing accounts. Use this resource to enable a list of existing accounts`,
+		Create:        resourceAwsGuardDutyOrganizationSettingsCreate,
+		Read:          resourceAwsGuardDutyOrganizationSettingsRead,
+		Update:        resourceAwsGuardDutyOrganizationSettingsUpdate,
+		Delete:        resourceAwsGuardDutyOrganizationSettingsDelete,
+		SchemaVersion: 1,
+		Schema: map[string]*schema.Schema{
+			"member_accounts": {
+				Description: "A list of AWS Organization member accounts to associate with the GuardDuty Administrator account.",
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Required:    true,
+			},
+			"detector_id": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.NoZeroValues,
+			},
+		},
+	}
+}
+
+func getMemberAccounts(d *schema.ResourceData) []string {
+	memberAccounts := ExpandStringSliceofPointers(ExpandStringSet(d.Get("member_accounts").(*schema.Set)))
+	return memberAccounts
+}
+
+func resourceAwsGuardDutyOrganizationSettingsCreate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+	memberAccounts := getMemberAccounts(d)
+	detectorID := d.Get("detector_id").(string)
+
+	if err := addGuardDutyOrganizationMembers(conn, detectorID, memberAccounts); err != nil {
+		return err
+	}
+
+	d.SetId(uuid.New().String())
+
+	return resourceAwsGuardDutyOrganizationSettingsRead(d, meta)
+}
+
+func resourceAwsGuardDutyOrganizationSettingsRead(d *schema.ResourceData, meta interface{}) error {
+	return nil
+}
+
+func resourceAwsGuardDutyOrganizationSettingsUpdate(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+	detectorID := d.Get("detector_id").(string)
+
+	if d.HasChange("member_accounts") {
+		old, new := d.GetChange("member_accounts")
+
+		oldExpanded := ExpandStringSliceofPointers(ExpandStringSet(old.(*schema.Set)))
+		newExpanded := ExpandStringSliceofPointers(ExpandStringSet(new.(*schema.Set)))
+
+		membersToAdd := Diff(newExpanded, oldExpanded)
+		if len(membersToAdd) > 0 {
+			if err := addGuardDutyOrganizationMembers(conn, detectorID, membersToAdd); err != nil {
+				return fmt.Errorf("error setting guardduty organization members: %s", err)
+			}
+		}
+
+		membersToRemove := Diff(oldExpanded, newExpanded)
+		if len(membersToRemove) > 0 {
+			if err := removeGuardDutyOrganizationMembers(conn, detectorID, membersToRemove); err != nil {
+				return fmt.Errorf("error removing guardduty organization members: %s", err)
+			}
+		}
+	}
+	return nil
+}
+
+func resourceAwsGuardDutyOrganizationSettingsDelete(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).guarddutyconn
+	detectorID := d.Get("detector_id").(string)
+	membersToRemove := getMemberAccounts(d)
+
+	if err := removeGuardDutyOrganizationMembers(conn, detectorID, membersToRemove); err != nil {
+		return fmt.Errorf("error removing guardduty organization members: %s", err)
+	}
+	return nil
+}
+
+func makeGuardDutyAccountDetails(accounts []string) []*guardduty.AccountDetail {
+	accountDetails := make([]*guardduty.AccountDetail, 0)
+	for i := range accounts {
+		accountDetails = append(accountDetails, &guardduty.AccountDetail{
+			AccountId: aws.String(accounts[i]),
+			Email:     aws.String("notused2join@awsorganization.com"),
+		})
+	}
+	return accountDetails
+}
+
+func makeGuardDutyAccountIDs(accounts []string) []*string {
+	accountIDs := make([]*string, 0)
+	for i := range accounts {
+		accountIDs = append(accountIDs, aws.String(accounts[i]))
+	}
+	return accountIDs
+}
+
+func addGuardDutyOrganizationMembers(conn *guardduty.GuardDuty, detectorID string, memberAccounts []string) error {
+	if len(memberAccounts) > 0 {
+		accountDetails := makeGuardDutyAccountDetails(memberAccounts)
+
+		createMembersInput := &guardduty.CreateMembersInput{
+			AccountDetails: accountDetails,
+			DetectorId:     &detectorID,
+		}
+
+		if result, err := conn.CreateMembers(createMembersInput); err != nil || len(result.UnprocessedAccounts) > 0 {
+			if err != nil {
+				return fmt.Errorf("error designating guardduty administrator account members: %s", err)
+			}
+			return fmt.Errorf("error designating guardduty administrator account members: %s", result.UnprocessedAccounts)
+		}
+	}
+	return nil
+}
+
+func removeGuardDutyOrganizationMembers(conn *guardduty.GuardDuty, detectorID string, memberAccounts []string) error {
+	accountIDs := makeGuardDutyAccountIDs(memberAccounts)
+	if len(memberAccounts) > 0 {
+		disassociateMembersInput := &guardduty.DisassociateMembersInput{
+			AccountIds: accountIDs,
+			DetectorId: &detectorID,
+		}
+
+		deleteMembersInput := &guardduty.DeleteMembersInput{
+			AccountIds: accountIDs,
+			DetectorId: &detectorID,
+		}
+
+		if _, err := conn.DisassociateMembers(disassociateMembersInput); err != nil {
+			if err != nil {
+				return fmt.Errorf("error disassociating guardduty administrator account members: %s", err)
+			}
+		}
+
+		if result, err := conn.DeleteMembers(deleteMembersInput); err != nil || len(result.UnprocessedAccounts) > 0 {
+			if err != nil {
+				return fmt.Errorf("error removing guardduty administrator account members: %s", err)
+			}
+			return fmt.Errorf("error removing guardduty administrator account members: %s", result.UnprocessedAccounts)
+		}
+	}
+	return nil
+}

--- a/internal/service/guardduty/errors.go
+++ b/internal/service/guardduty/errors.go
@@ -1,0 +1,5 @@
+package securityhub
+
+const (
+	ErrCodeBadRequestException = "BadRequestException"
+)

--- a/internal/service/guardduty/finder/finder.go
+++ b/internal/service/guardduty/finder/finder.go
@@ -1,0 +1,42 @@
+package finder
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/guardduty"
+)
+
+func AdminAccount(conn *guardduty.GuardDuty, adminAccountID string) (*guardduty.AdminAccount, error) {
+	input := &guardduty.ListOrganizationAdminAccountsInput{}
+	var result *guardduty.AdminAccount
+
+	err := conn.ListOrganizationAdminAccountsPages(input, func(page *guardduty.ListOrganizationAdminAccountsOutput, lastPage bool) bool {
+		if page == nil {
+			return !lastPage
+		}
+
+		for _, adminAccount := range page.AdminAccounts {
+			if adminAccount == nil {
+				continue
+			}
+
+			if aws.StringValue(adminAccount.AdminAccountId) == adminAccountID {
+				result = adminAccount
+				return false
+			}
+		}
+
+		return !lastPage
+	})
+
+	return result, err
+}
+
+func GuardDutyOrganizationSettingsAutoEnabled(conn *guardduty.GuardDuty, detectorID string) (bool, error) {
+	input := &guardduty.DescribeOrganizationConfigurationInput{DetectorId: &detectorID}
+	settings, err := conn.DescribeOrganizationConfiguration(input)
+	if err != nil {
+		return false, err
+	}
+
+	return *settings.AutoEnable, err
+}


### PR DESCRIPTION
## what

* Add the `awsutils_guardduty_organization_settings` resource

## why
* The official AWS Terraform Provider does not provide a method to enroll existing AWS Organization accounts when setting a GuardDuty Administrator account