### PR TITLE
feat(resource): Add Export VPN Client Config to awsutils

### DIFF
--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -17,6 +17,6 @@ resource "awsutils_default_vpc_deletion" "example" {
 }
 
 # Export default VPN client config
-resource "awsutils_export_client_config" "default" {
+data "awsutils_ec2_client_vpn_export_client_config" "default" {
     client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.default.id
 }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -15,3 +15,8 @@ provider "awsutils" {
 # Delete default VPC
 resource "awsutils_default_vpc_deletion" "example" {
 }
+
+# Export default VPN client config
+resource "awsutils_export_client_config" "default" {
+    client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.default.id
+}

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/aws/aws-sdk-go v1.38.67
+	github.com/aws/aws-sdk-go-v2 v1.8.0 // indirect
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/google/uuid v1.2.0
 	github.com/hashicorp/aws-sdk-go-base v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -76,6 +76,9 @@ github.com/aws/aws-sdk-go v1.25.3/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.31.9/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.38.67 h1:OCeXMKiiM8X7HAKPCE5yD+t+sEsRaj8EwDs2tlgvX2c=
 github.com/aws/aws-sdk-go v1.38.67/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go-v2 v1.8.0 h1:HcN6yDnHV9S7D69E7To0aUppJhiJNEzQSNcUxc7r3qo=
+github.com/aws/aws-sdk-go-v2 v1.8.0/go.mod h1:xEFuWz+3TYdlPRuo+CqATbeDWIWyaT5uAPwPaWtgse0=
+github.com/aws/smithy-go v1.7.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
@@ -157,6 +160,7 @@ github.com/google/go-cmp v0.4.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=

--- a/internal/provider/data_source_awsutils_ec2_client_vpn_export_client_config.go
+++ b/internal/provider/data_source_awsutils_ec2_client_vpn_export_client_config.go
@@ -1,8 +1,8 @@
 package provider
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"github.com/cloudposse/terraform-provider-awsutils/internal/service/ec2/finder"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -17,23 +17,28 @@ func dataSourceAwsUtilsEc2ExportClientVpnClientConfiguration() *schema.Resource 
 				Type:        schema.TypeString,
 				Computed:    true,
 			},
+			"client_configuration": {
+				Description: "Output from 'export-client-vpn-client-configuration' call",
+				Type:        schema.TypeString,
+				Computed:    false,
+			},
 		},
 	}
 }
 
 func dataSourceAwsUtilsEc2ExportClientVpnClientConfigurationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
-	var vpc *ec2.Vpc
+	params := &ec2.ExportClientVpnClientConfigurationInput{}
 
-	vpc, err := finder.VpcDefault(conn)
+	id := d.Get("id").(string)
+	params.ClientVpnEndpointId = aws.String(id)
+
+	resp, err := conn.ExportClientVpnClientConfiguration(params)
 	if err != nil {
 		return err
 	}
 
-	if !d.IsNewResource() && vpc != nil {
-		d.SetId("")
-	}
+	d.Set("client_configuration", resp.ClientConfiguration)
 
 	return nil
-
 }

--- a/internal/provider/data_source_awsutils_ec2_client_vpn_export_client_config.go
+++ b/internal/provider/data_source_awsutils_ec2_client_vpn_export_client_config.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/cloudposse/terraform-provider-awsutils/internal/service/ec2/finder"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+func dataSourceAwsUtilsEc2ExportClientVpnClientConfiguration() *schema.Resource {
+	return &schema.Resource{
+		Description:   `Passthru for configuring and executing ` + "`aws ec2 export-client-vpn-client-configuration`",
+		Read:          dataSourceAwsUtilsEc2ExportClientVpnClientConfigurationRead,
+		SchemaVersion: 1,
+		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the VPN endpoint to export the config for.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func dataSourceAwsUtilsEc2ExportClientVpnClientConfigurationRead(d *schema.ResourceData, meta interface{}) error {
+	conn := meta.(*AWSClient).ec2conn
+	var vpc *ec2.Vpc
+
+	vpc, err := finder.VpcDefault(conn)
+	if err != nil {
+		return err
+	}
+
+	if !d.IsNewResource() && vpc != nil {
+		d.SetId("")
+	}
+
+	return nil
+
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -183,8 +183,9 @@ func Provider() *schema.Provider {
 			},
 		},
 
-		DataSourcesMap: map[string]*schema.Resource{},
-
+		DataSourcesMap: map[string]*schema.Resource{
+			"awsutils_ec2_client_vpn_export_client_config": dataSourceAwsUtilsEc2ClientVpnClientExportConfiguration(),
+		},
 		ResourcesMap: map[string]*schema.Resource{
 			"awsutils_default_vpc_deletion":               resourceAwsUtilsDefaultVpcDeletion(),
 			"awsutils_guardduty_organization_settings":    resourceAwsUtilsGuardDutyOrganizationSettings(),

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -184,7 +184,7 @@ func Provider() *schema.Provider {
 		},
 
 		DataSourcesMap: map[string]*schema.Resource{
-			"awsutils_ec2_client_vpn_export_client_config": dataSourceAwsUtilsEc2ClientVpnClientExportConfiguration(),
+			"awsutils_ec2_client_vpn_export_client_config": dataSourceAwsUtilsEc2ExportClientVpnClientConfiguration(),
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"awsutils_default_vpc_deletion":               resourceAwsUtilsDefaultVpcDeletion(),

--- a/internal/service/ec2/finder/finder.go
+++ b/internal/service/ec2/finder/finder.go
@@ -5,7 +5,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ec2"
 )
 
-// VpcDefault looks up the Default Vpc. When not found, returns nil and potentially an API error.
+// InternetGatewayForVPC looks up the Internet Gateway for the given VPC. When not found, returns nil and potentially an API error.
 func InternetGatewayForVPC(conn *ec2.EC2, vpcID string) (*ec2.InternetGateway, error) {
 	filters := []*ec2.Filter{
 		{


### PR DESCRIPTION
## what
* Adding a feature that is commonly used with TF `provisioner` to export the VPN client config

### Example Use Case
Takes
```hcl
resource "null_resource" "export_client_config" {
  provisioner "local-exec" {
    command = <<-EOT
    mkdir -p ${path.root}/vpn_config/ && \
    aws ec2 export-client-vpn-client-configuration \
            --client-vpn-endpoint-id ${aws_ec2_client_vpn_endpoint.default.id} \
            --output text > ${path.root}/vpn_config/${module.this.id}-client-config-original.ovpn \
            --region ${var.region}
    sed -i ".backup" "s/remote cvpn/remote asdf.cvpn/g" ${path.root}/vpn_config/${module.this.id}-client-config-original.ovpn
    rm ${path.root}/vpn_config/${module.this.id}-client-config-original.ovpn.backup
EOT
  }
```

makes it

```hcl
data "awsutils_ec2_client_vpn_export_client_config" "default" {
    client_vpn_endpoint_id = aws_ec2_client_vpn_endpoint.default.id
}
```


## why
* `provisioner` is a bad smell and isn't easy to maintain since it encapsulates provisioning instructions within TF HCL.
* This is intended to generalize `provisioner` instructions into repeatable/reusable context from a provider.

## references
* N/A

