### PR TITLE
fix(datasource): Datasource output for client_configuration missing id field

### DIFF
--- a/internal/provider/data_source_awsutils_ec2_client_vpn_export_client_config.go
+++ b/internal/provider/data_source_awsutils_ec2_client_vpn_export_client_config.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -29,8 +30,11 @@ func dataSourceAwsUtilsEc2ExportClientVpnClientConfiguration() *schema.Resource 
 func dataSourceAwsUtilsEc2ExportClientVpnClientConfigurationRead(d *schema.ResourceData, meta interface{}) error {
 	conn := meta.(*AWSClient).ec2conn
 	params := &ec2.ExportClientVpnClientConfigurationInput{}
+	var id string
 
-	id := d.Get("id").(string)
+	if v, ok := d.GetOk("id"); ok {
+		id = v.(string)
+	}
 	params.ClientVpnEndpointId = aws.String(id)
 
 	resp, err := conn.ExportClientVpnClientConfiguration(params)
@@ -38,7 +42,10 @@ func dataSourceAwsUtilsEc2ExportClientVpnClientConfigurationRead(d *schema.Resou
 		return err
 	}
 
-	d.Set("client_configuration", resp.ClientConfiguration)
+	d.SetId(id)
+	if err := d.Set("client_configuration", *resp.ClientConfiguration); err != nil {
+		return fmt.Errorf("error setting names: %w", err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## what
* Added the appropriate id field to the `client_configuration`

## why
* Without the `id`, the result is invalid and is returned as a `null`

## references
* N/A

