### PR TITLE
bump go version in github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.16"
+          go-version: 1.17
         id: go
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
## what

* Fix the `golang` version in `github actions`

## why

* Currently the release action is failing because of a version mismatch between `go.mod` and the `release.yml` action