### PR TITLE
update goreleaser timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16
+          go-version: 1.17
 
       - name: Import GPG key
         id: import_gpg

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v2
         with:
           version: latest
-          args: release --parallelism 5 --rm-dist --timeout 60m
+          args: release --rm-dist --timeout 120m
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2.1.3
         with:
-          go-version: "1.16"
+          go-version: 1.17
         id: go
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
## what

* Update `goreleaser` timeout
* remove `parallelism` flag

## why
* Builds are currently taking longer than 60m
* The `parallelism` defaults to the number of CPUs, so setting it higher actually may cause it to build slower
