### PR TITLE
fix documentation typo

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -78,7 +78,7 @@ usage: |-
     }
   }
 
-  provdier "awsutils" {
+  provider "awsutils" {
     region = "us-east-2"
   }
   ```


### PR DESCRIPTION
## what

README has a typo that makes copy-pasting the syntax not work.