### PR TITLE
Run disk space check on goreleaser failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check disk space after
+        if: success() || failure()
         shell: bash
         run: |-
           set -x


### PR DESCRIPTION
## what

- Run disk space check on `goreleaser` failure

## why

- Debugging why releases fail with "no space left on device"