### PR TITLE
Switch to using GHA runner set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,7 @@ on:
 
 jobs:
   goreleaser:
-    runs-on:
-      - "self-hosted"
-      - "amd64"
-      - "large"
+    runs-on: "self-hosted-large"
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
## what

- Move builder workflow to GitHub Action Runner Set

## why

- Replacing self-hosted "runners" with "runner set"



