### PR TITLE
Enable runs-on

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -1,0 +1,2 @@
+# See https://runs-on.com/configuration/repo-config/
+_extends: .github


### PR DESCRIPTION
## what
* Added runs on config

## why
* Github public runners have low disk space for go release 

## references
* https://github.com/cloudposse/terraform-provider-awsutils/actions/runs/13504257115
