### PR TITLE
Use runs-on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,4 +91,5 @@ jobs:
     uses: cloudposse/.github/.github/workflows/shared-go-auto-release.yml@main
     with:
       publish: true
+      runs-on: '["runs-on=${{ github.run_id }}", "runner=default", "extras=s3-cache"]'
     secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,5 +91,5 @@ jobs:
     uses: cloudposse/.github/.github/workflows/shared-go-auto-release.yml@main
     with:
       publish: true
-      runs-on: '["runs-on=${{ github.run_id }}", "runner=default", "extras=s3-cache"]'
+      runs-on: '["runs-on=${{ github.run_id }}", "runner=default"]'
     secrets: inherit


### PR DESCRIPTION
## what
* Use runs on

## why
* Github public runners have low disk space for go release 

## references
* https://github.com/cloudposse/terraform-provider-awsutils/actions/runs/13504257115
