### PR TITLE
Use large disk size for go releases

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,5 +91,5 @@ jobs:
     uses: cloudposse/.github/.github/workflows/shared-go-auto-release.yml@main
     with:
       publish: true
-      runs-on: '["runs-on=${{ github.run_id }}", "runner=default"]'
+      runs-on: '["runs-on=${{ github.run_id }}", "runner=medium", "disk=large"]'
     secrets: inherit


### PR DESCRIPTION
## what
* Use large disk size for go releases

## why
* Solve disk space shortage


